### PR TITLE
mastodon: add support for Emoji reactions, Glitch style

### DIFF
--- a/lib/mastodon.dart
+++ b/lib/mastodon.dart
@@ -18,6 +18,7 @@ export 'src/mastodon/poll_option.dart';
 export 'src/mastodon/poll.dart';
 export 'src/mastodon/push_subscription_alerts.dart';
 export 'src/mastodon/push_subscription.dart';
+export 'src/mastodon/reaction.dart';
 export 'src/mastodon/replies_policy.dart';
 export 'src/mastodon/role.dart';
 export 'src/mastodon/scheduled_status_params.dart';

--- a/lib/pleroma.dart
+++ b/lib/pleroma.dart
@@ -6,7 +6,6 @@ export 'src/pleroma/card.dart';
 export 'src/pleroma/chat.dart';
 export 'src/pleroma/chat_message.dart';
 export 'src/pleroma/emoji_pack.dart';
-export 'src/pleroma/emoji_reaction.dart';
 export 'src/pleroma/frontend_configuration.dart';
 export 'src/pleroma/pleroma_frontend_configuration.dart';
 export 'src/pleroma/status.dart';

--- a/lib/src/mastodon/reaction.dart
+++ b/lib/src/mastodon/reaction.dart
@@ -1,11 +1,12 @@
-import 'package:fediverse_objects/src/mastodon/account.dart';
+import 'account.dart';
 import 'package:json_annotation/json_annotation.dart';
 
-part 'emoji_reaction.g.dart';
+part 'reaction.g.dart';
 
 @JsonSerializable()
-class EmojiReaction {
+class Reaction {
   /// Array of accounts reacted with this emoji
+  /// (Pleroma only)
   final Iterable<Account>? accounts;
 
   /// Count of reactions with this emoji
@@ -17,15 +18,19 @@ class EmojiReaction {
   /// Emoji
   final String name;
 
-  const EmojiReaction({
+  /// URL (For custom emoji)
+  final String? url;
+
+  const Reaction({
     required this.accounts,
     required this.count,
     required this.me,
     required this.name,
+    this.url,
   });
 
-  factory EmojiReaction.fromJson(Map<String, dynamic> json) =>
-      _$EmojiReactionFromJson(json);
+  factory Reaction.fromJson(Map<String, dynamic> json) =>
+      _$ReactionFromJson(json);
 
-  Map<String, dynamic> toJson() => _$EmojiReactionToJson(this);
+  Map<String, dynamic> toJson() => _$ReactionToJson(this);
 }

--- a/lib/src/mastodon/reaction.g.dart
+++ b/lib/src/mastodon/reaction.g.dart
@@ -1,17 +1,16 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'emoji_reaction.dart';
+part of 'reaction.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-EmojiReaction _$EmojiReactionFromJson(Map<String, dynamic> json) =>
-    $checkedCreate(
-      'EmojiReaction',
+Reaction _$ReactionFromJson(Map<String, dynamic> json) => $checkedCreate(
+      'Reaction',
       json,
       ($checkedConvert) {
-        final val = EmojiReaction(
+        final val = Reaction(
           accounts: $checkedConvert(
               'accounts',
               (v) => (v as List<dynamic>?)
@@ -19,15 +18,16 @@ EmojiReaction _$EmojiReactionFromJson(Map<String, dynamic> json) =>
           count: $checkedConvert('count', (v) => v as int),
           me: $checkedConvert('me', (v) => v as bool),
           name: $checkedConvert('name', (v) => v as String),
+          url: $checkedConvert('url', (v) => v as String?),
         );
         return val;
       },
     );
 
-Map<String, dynamic> _$EmojiReactionToJson(EmojiReaction instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ReactionToJson(Reaction instance) => <String, dynamic>{
       'accounts': instance.accounts?.toList(),
       'count': instance.count,
       'me': instance.me,
       'name': instance.name,
+      'url': instance.url,
     };

--- a/lib/src/mastodon/status.dart
+++ b/lib/src/mastodon/status.dart
@@ -6,6 +6,7 @@ import 'application.dart';
 import 'attachment.dart';
 import 'card.dart';
 import 'emoji.dart';
+import 'reaction.dart';
 import 'mention.dart';
 import 'poll.dart';
 import 'tag.dart';
@@ -110,6 +111,9 @@ class Status {
   /// Returned instead of `content` when status is deleted, so the user may redraft from the source text without the client having to reverse-engineer the original text from the HTML content.
   final String? text;
 
+  /// Emoji Reactions (Glitch extension)
+  final Iterable<Reaction>? reactions;
+
   Status({
     required this.account,
     this.application,
@@ -141,6 +145,7 @@ class Status {
     this.url,
     this.text,
     this.poll,
+    this.reactions,
   });
 
   factory Status.fromJson(Map<String, dynamic> json) => _$StatusFromJson(json);

--- a/lib/src/mastodon/status.g.dart
+++ b/lib/src/mastodon/status.g.dart
@@ -78,6 +78,10 @@ Status _$StatusFromJson(Map<String, dynamic> json) => $checkedCreate(
               'poll',
               (v) =>
                   v == null ? null : Poll.fromJson(v as Map<String, dynamic>)),
+          reactions: $checkedConvert(
+              'reactions',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))),
         );
         return val;
       },
@@ -124,4 +128,5 @@ Map<String, dynamic> _$StatusToJson(Status instance) => <String, dynamic>{
       'url': instance.url,
       'visibility': instance.visibility,
       'text': instance.text,
+      'reactions': instance.reactions?.toList(),
     };

--- a/lib/src/pleroma/status.dart
+++ b/lib/src/pleroma/status.dart
@@ -1,4 +1,4 @@
-import 'package:fediverse_objects/src/pleroma/emoji_reaction.dart';
+import 'package:fediverse_objects/src/mastodon/reaction.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'status.g.dart';
@@ -14,7 +14,7 @@ class PleromaStatus {
   //final dynamic directConversationId;
 
   @JsonKey(name: 'emoji_reactions')
-  final Iterable<EmojiReaction>? emojiReactions;
+  final Iterable<Reaction>? emojiReactions;
 
   @JsonKey(name: 'expires_at')
   final DateTime? expiresAt;

--- a/lib/src/pleroma/status.g.dart
+++ b/lib/src/pleroma/status.g.dart
@@ -20,8 +20,8 @@ PleromaStatus _$PleromaStatusFromJson(Map<String, dynamic> json) =>
           $checkedConvert('conversation_id', (v) => v as int?),
           $checkedConvert(
               'emoji_reactions',
-              (v) => (v as List<dynamic>?)?.map(
-                  (e) => EmojiReaction.fromJson(e as Map<String, dynamic>))),
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) => Reaction.fromJson(e as Map<String, dynamic>))),
           $checkedConvert('expires_at',
               (v) => v == null ? null : DateTime.parse(v as String)),
           $checkedConvert('in_reply_to_account_acct', (v) => v as String?),


### PR DESCRIPTION
 * Move EmojiReaction from Pleroma to Mastodon and rename to Reaction (Aligns with name used in upstream Mastodon API for emoji reactions on announcements)
 * Add "url" property to Reaction, for use by custom emoji (This is compatible between Akkoma and Glitch + fork)
 * Add "reactions" property to status (glitch-soc + fork only)
 * Update pleroma.Status to reference mastodon.Reaction

I have a (WIP) Kaiteki PR which goes along with this